### PR TITLE
feat: sanitize markdown content

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react-hook-form": "^7.62.0",
     "react-markdown": "^10.1.0",
     "rehype-raw": "^7.0.0",
+    "rehype-sanitize": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",

--- a/src/components/RichText.tsx
+++ b/src/components/RichText.tsx
@@ -4,12 +4,21 @@ import React from 'react'
 import ReactMarkdown, { type Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import rehypeRaw from 'rehype-raw'
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
 
 type RichTextProps = {
   markdown: string
   className?: string
   // RTL pour l'arabe
   rtl?: boolean
+}
+
+const schema = {
+  ...defaultSchema,
+  attributes: {
+    ...defaultSchema.attributes,
+    code: [...(defaultSchema.attributes.code || []), ['className']],
+  },
 }
 
 // Type “safe” pour le renderer <code>, compatible avec toutes versions
@@ -67,7 +76,7 @@ export default function RichText({ markdown, className, rtl }: RichTextProps) {
     <div className={className ?? 'prose prose-lg max-w-none'} dir={rtl ? 'rtl' : undefined}>
       <ReactMarkdown
         remarkPlugins={[remarkGfm]}
-        rehypePlugins={[rehypeRaw]}
+        rehypePlugins={[rehypeRaw, [rehypeSanitize, schema]]}
         components={components}
       >
         {markdown}


### PR DESCRIPTION
## Summary
- sanitize rich text by adding rehype-sanitize with custom schema
- declare rehype-sanitize dependency

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 13 errors, 15 warnings)*
- `npx tsx sanitize-test.tsx` *(fails: Cannot find module 'rehype-sanitize')*


------
https://chatgpt.com/codex/tasks/task_e_68bd8bea39348327bcb77f00fc894377