### PR TITLE
feat: persist locale using cookies

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,11 @@
-import type { NextConfig } from "next";
+import type { NextConfig } from "next"
+import { locales, defaultLocale } from "./src/i18n/config"
 
 const nextConfig: NextConfig = {
-  /* config options here */
-};
+  i18n: {
+    locales,
+    defaultLocale,
+  },
+}
 
-export default nextConfig;
+export default nextConfig

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,8 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Navigation from "@/components/Navigation";
 import { NextAuthProvider } from "@/components/NextAuthProvider";
+import { cookies } from "next/headers";
+import { defaultLocale, isRtl, Locale, locales } from "@/i18n/config";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -72,8 +74,10 @@ export default function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
+  const localeCookie = cookies().get('locale')?.value as Locale | undefined
+  const locale = locales.includes(localeCookie as Locale) ? (localeCookie as Locale) : defaultLocale
   return (
-    <html lang="fr">
+    <html lang={locale} dir={isRtl(locale) ? 'rtl' : 'ltr'}>
       <body
         className="antialiased"
         style={{

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,16 +2,19 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
+import { useRouter } from 'next/navigation'
 import { Menu, X, Globe, BookOpen, Trophy, User, LogOut, Settings, BarChart3 } from 'lucide-react'
 import { useSession, signOut } from 'next-auth/react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { localeNames } from '@/i18n/config'
+import { useLocaleCookie } from '@/i18n/use-locale'
 
 export default function Navigation() {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
-  const [currentLocale, setCurrentLocale] = useState('fr')
+  const [currentLocale, setCurrentLocale] = useLocaleCookie()
+  const router = useRouter()
   const { data: session, status } = useSession()
 
   const navigation = [
@@ -63,7 +66,11 @@ export default function Navigation() {
               <Button
                 variant="ghost"
                 size="sm"
-                onClick={() => setCurrentLocale(currentLocale === 'fr' ? 'en' : currentLocale === 'en' ? 'ar' : 'fr')}
+                onClick={() => {
+                  const next = currentLocale === 'fr' ? 'en' : currentLocale === 'en' ? 'ar' : 'fr'
+                  setCurrentLocale(next)
+                  router.refresh()
+                }}
                 className="flex items-center space-x-2"
               >
                 <Globe className="h-4 w-4" />

--- a/src/i18n/use-locale.ts
+++ b/src/i18n/use-locale.ts
@@ -1,0 +1,34 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { defaultLocale, Locale, locales } from './config'
+
+const COOKIE_NAME = 'locale'
+
+function readLocale(): Locale {
+  if (typeof document === 'undefined') return defaultLocale
+  const cookie = document.cookie
+    .split('; ')
+    .find((c) => c.startsWith(`${COOKIE_NAME}=`))
+  const value = cookie?.split('=')[1]
+  return locales.includes(value as Locale) ? (value as Locale) : defaultLocale
+}
+
+function writeLocale(locale: Locale) {
+  document.cookie = `${COOKIE_NAME}=${locale}; path=/; max-age=31536000`
+}
+
+export function useLocaleCookie() {
+  const [locale, setLocale] = useState<Locale>(defaultLocale)
+
+  useEffect(() => {
+    setLocale(readLocale())
+  }, [])
+
+  const updateLocale = (newLocale: Locale) => {
+    writeLocale(newLocale)
+    setLocale(newLocale)
+  }
+
+  return [locale, updateLocale] as const
+}


### PR DESCRIPTION
## Summary
- enable Next.js i18n routing with French, English and Arabic locales
- add cookie-based locale hook and refresh router on change
- wire layout to read locale cookie and adjust lang/dir attributes

## Testing
- `npm test` (fails: Missing script)
- `npm run lint` (fails: 13 errors, 15 warnings)
- `npx eslint src/components/Navigation.tsx src/app/layout.tsx src/i18n/use-locale.ts next.config.ts`


------
https://chatgpt.com/codex/tasks/task_e_68bd8bebb0e883278fbaf486c7678eff