### PR TITLE
Fix lesson page params and access check

### DIFF
--- a/src/app/lessons/[slug]/page.tsx
+++ b/src/app/lessons/[slug]/page.tsx
@@ -6,15 +6,15 @@ import { getLessonBySlug } from '@/data/all-lessons'
 import { getLevelById } from '@/data/levels'
 import { hasUnlockedAccess } from '@/lib/access'
 
-export default async function LessonPage({ params }: { params: Promise<{ slug: string }> }) {
-  const { slug } = await params
+export default async function LessonPage({ params }: { params: { slug: string } }) {
+  const { slug } = params
 
   // Récupérer la leçon basée sur le slug
   const lesson = getLessonBySlug(slug)
   if (!lesson) {
     notFound()
   }
-  const unlocked = hasUnlockedAccess()
+  const unlocked = await hasUnlockedAccess()
   if (lesson.isLocked && !unlocked) {
     return (
       <div className="min-h-screen bg-gray-50">


### PR DESCRIPTION
## Summary
- Simplify lesson page params typing
- Await access check and use returned boolean

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 13 errors, 15 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bd82f898b083278b3a3ddb16ed79ab